### PR TITLE
Prepend the lessc call with an explicit call to the nodejs binary with the '--no-deprecation' flag

### DIFF
--- a/Css/PreProcessor/Adapter/Less/Processor.php
+++ b/Css/PreProcessor/Adapter/Less/Processor.php
@@ -115,18 +115,20 @@ class Processor implements ContentProcessorInterface
      */
     protected function compileFile($filePath)
     {
-        $cmdArgs = $this->getCompilerArgsAsString();
-        $cmd = "%s $cmdArgs %s";
+        $nodeCmdArgs = $this->getNodeArgsAsString();
+        $lessCmdArgs = $this->getCompilerArgsAsString();
+        $cmd = "%s $nodeCmdArgs %s $lessCmdArgs %s";
 
         // to log or not to log, that's the question
         // also, it would be better to use the logger in the Shell class,
         // since that one will contain the exact correct command, and not this sprintf version
         // $this->logger->debug('Less compilation command: `'
-        //     . sprintf($cmd, $this->getPathToLessCompiler(), $filePath)
+        //     . sprintf($cmd, $this->getPathToNodeBinary(), $this->getPathToLessCompiler(), $filePath)
         //     . '`');
 
         return $this->shell->execute($cmd,
             [
+                $this->getPathToNodeBinary(),
                 $this->getPathToLessCompiler(),
                 $filePath,
             ]
@@ -153,6 +155,29 @@ class Processor implements ContentProcessorInterface
     protected function getPathToLessCompiler()
     {
         return BP . '/node_modules/.bin/lessc';
+    }
+
+    /**
+     * Get all arguments which will be used in the cli call with the nodejs binary
+     *
+     * @return string
+     */
+    protected function getNodeArgsAsString()
+    {
+        $args = ['--no-deprecation']; // squelch warnings about deprecated modules being used
+
+        return implode(' ', $args);
+    }
+
+    /**
+     * Get the path to the nodejs binary
+     *
+     * @return string
+     */
+    protected function getPathToNodeBinary()
+    {
+        // we assume it's globally available
+        return 'node';
     }
 
     /**


### PR DESCRIPTION
Discovered on a server with these versions:
- npm: 3.10.10
- nodejs: v6.12.2

When executing the `lessc` binary on this server and then writing the output to a css file, the css files can contain invalid css because node is complaining about deprecated modules in use. This then makes the css file incorrect and the browser is not able to parse parts of the css file because of this.
For example, the css file can have this string as the first line: `(node:87545) fs:re-evaluating native module sources is not supported. If you are using the graceful-fs module,please update it to a more recent version.`

Currently solved by explicitly calling the nodejs binary with the flag `--no-deprecation`.

Will keep this PR open for a few days until I've experimented with this change on a couple of other servers to make sure this keeps working correctly on different versions of npm & nodejs.
