### PR TITLE
exclude vendor-bin, composer.lock, Makefile from archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+composer.lock export-ignore
+Makefile      export-ignore
+vendor-bin/   export-ignore


### PR DESCRIPTION
Based on https://git-scm.com/docs/gitattributes#_creating_an_archive